### PR TITLE
Add a missing import in the example

### DIFF
--- a/cmd/goagain-example/goagain-example.go
+++ b/cmd/goagain-example/goagain-example.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"time"
 )
 
 func main() {


### PR DESCRIPTION
Without this, I get :

```
bbigras@ubuntu-machinage:~/dev/go$ go run goagain-example.go
# command-line-arguments
./goagain-example.go:59: undefined: time
```
