### PR TITLE
Fixup return statement warning on module install

### DIFF
--- a/goagain.go
+++ b/goagain.go
@@ -51,7 +51,7 @@ func AwaitSignals(l net.Listener) error {
 		}
 	}
 
-        return
+        return nil
 }
 
 // Convert and validate the GOAGAIN_FD, GOAGAIN_NAME, and GOAGAIN_PPID

--- a/goagain.go
+++ b/goagain.go
@@ -50,6 +50,8 @@ func AwaitSignals(l net.Listener) error {
 
 		}
 	}
+
+        return
 }
 
 // Convert and validate the GOAGAIN_FD, GOAGAIN_NAME, and GOAGAIN_PPID


### PR DESCRIPTION
Hi,

Fresh to golang - but noticed when installing your goagain module it produces a warning (which is causing issues with my puppet provider). Warning is:

```
root@ops-foo:~# go get github.com/rcrowley/goagain     
# github.com/rcrowley/goagain
/usr/lib/go/src/pkg/github.com/rcrowley/goagain/goagain.go:23: function ends without a return statement
```
