### PR TITLE
fix another go get errors

### DIFF
--- a/goagain.go
+++ b/goagain.go
@@ -246,7 +246,7 @@ func Wait(l net.Listener) (syscall.Signal, error) {
 
 		}
 	}
-	return nil, nil
+	return syscall.SIGQUIT, nil
 }
 
 func lookPath() (argv0 string, err error) {

--- a/goagain.go
+++ b/goagain.go
@@ -246,6 +246,7 @@ func Wait(l net.Listener) (syscall.Signal, error) {
 
 		}
 	}
+	return nil, nil
 }
 
 func lookPath() (argv0 string, err error) {


### PR DESCRIPTION
go get github.com/rcrowley/goagain on ubuntu results in 
github.com/rcrowley/goagain/goagain.go:191: function ends without a return statement
for me. 

this PR fixes this.
