### PR TITLE
Allow logging to be overridden

### DIFF
--- a/goagain.go
+++ b/goagain.go
@@ -47,7 +47,19 @@ var (
 
 	// The strategy to use; Single by default.
 	Strategy strategy = Single
+
+	Logger *log.Logger
 )
+
+func init() {
+	Logger = log.New(os.Stderr, "", log.LstdFlags)
+}
+
+func logln(v ...interface{}) {
+	if Logger != nil {
+		Logger.Println(v...)
+	}
+}
 
 // Re-exec this same image without dropping the net.Listener.
 func Exec(l net.Listener) error {
@@ -69,7 +81,7 @@ func Exec(l net.Listener) error {
 	); nil != err {
 		return err
 	}
-	log.Println("re-executing", argv0)
+	logln("re-executing", argv0)
 	return syscall.Exec(argv0, os.Args, os.Environ())
 }
 
@@ -123,7 +135,7 @@ func ForkExec(l net.Listener) error {
 	if nil != err {
 		return err
 	}
-	log.Println("spawned child", p.Pid)
+	logln("spawned child", p.Pid)
 	if err = os.Setenv("GOAGAIN_PID", fmt.Sprint(p.Pid)); nil != err {
 		return err
 	}
@@ -159,7 +171,7 @@ func Kill() error {
 	if syscall.SIGQUIT == sig && Double == Strategy {
 		go syscall.Wait4(pid, nil, 0, nil)
 	}
-	log.Println("sending signal", sig, "to process", pid)
+	logln("sending signal", sig, "to process", pid)
 	return syscall.Kill(pid, sig)
 }
 
@@ -205,14 +217,14 @@ func Wait(l net.Listener) (syscall.Signal, error) {
 	forked := false
 	for {
 		sig := <-ch
-		log.Println(sig.String())
+		logln(sig.String())
 		switch sig {
 
 		// SIGHUP should reload configuration.
 		case syscall.SIGHUP:
 			if nil != OnSIGHUP {
 				if err := OnSIGHUP(l); nil != err {
-					log.Println("OnSIGHUP:", err)
+					logln("OnSIGHUP:", err)
 				}
 			}
 
@@ -232,7 +244,7 @@ func Wait(l net.Listener) (syscall.Signal, error) {
 		case syscall.SIGUSR1:
 			if nil != OnSIGUSR1 {
 				if err := OnSIGUSR1(l); nil != err {
-					log.Println("OnSIGUSR1:", err)
+					logln("OnSIGUSR1:", err)
 				}
 			}
 


### PR DESCRIPTION
I agree with #2 and #3 that logging should not forced upon users of this library. But I also agree with @rcrowley that the logging is useful and needed. This PR doesn't change the default logging functionality but adds a `Logger` var on the package that can be set to override where log messages go.

This can be useful for applications that already have a logger setup and want the goagain logs to go to the same place. You just set 

``` go
myLogger := log.New(myWriter, "err: ", log.LstdFlags)
goagain.Logger = myLogger
```

Or if you wanted to disable logging altogether, you can set 

``` go
goagain.Logger = nil
```
